### PR TITLE
INTERLOK-3188 on snapshot, don't cache "changing modules"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,15 @@ configurations {
     all*.exclude group: 'org.hibernate', module: 'hibernate-validator'
 }
 
+
+if (interlokVersion.endsWith("SNAPSHOT") || interlokUiVersion.endsWith("SNAPSHOT")) {
+  allprojects {
+    configurations.all {
+      resolutionStrategy.cacheChangingModulesFor 0, "seconds"
+    }
+  }
+}
+
 repositories {
     mavenCentral()
     maven { url "${nexusBaseUrl}/nexus/content/groups/public" }


### PR DESCRIPTION
## Motivation:

If the version is a snapshot, then we accept that they might change
at any time (for instance you might publish a custom branch to nexus).
In that instance we should force gradle to recheck the dependencies.

## Modification:

Add an if statement in the parent based on interlokVersion/interlokUiVersion
which changes the resolution strategy to 0 seconds if they end with
'SNAPSHOT'

## Result:

No function change for most users
Users that specify 3.10-SNAPSHOT always check nexus.

## Testing

If we take the recent PR merge for es5; prior to this change, and we have a project that uses 3.10-SNAPSHOT and it would be 

```
Bootstrap of Interlok 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT) complete
Version Information
  Base Interlok: 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT)
....
  Interlok/ElasticSearch (5+) Integration: 3.10-SNAPSHOT(2020-02-27:06:14:27 UTC)
```

Then we build+publish the branch that the PR was on (shared-transport-client), this wouldn't traditionally be picked up; but with the changes in place in the parent we now have.

```
Bootstrap of Interlok 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT) complete
Version Information
  Base Interlok: 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT)
....
  Interlok/ElasticSearch (5+) Integration: 3.10-SNAPSHOT(2020-02-27:shared-transport-client)
```

And now that it has been merged, and the CI pipeline has taken place...

```
> Task :interlokVersionReport
Bootstrap of Interlok 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT) complete
Version Information
  Base Interlok: 3.10-SNAPSHOT(2020-02-27:02:44:42 GMT)
  .... 
 Interlok/ElasticSearch (5+) Integration: 3.10-SNAPSHOT(2020-02-27:09:58:18 GMT)
``

