### PR TITLE
INTERLOK-3200 Add support for spaces in path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ ext.buildDetails = [
   }
 ]
 
+def asFileUrl(filepath) {
+  return new java.net.URL(new java.net.URI("file", filepath, null).toASCIIString()).toString();
+}
+
+
 def overwriteWithPropertiesTemplate(file, dir){
     if(new File("${dir}/${file}-${buildEnv}.properties").exists()){
         ant.copy(file: "${dir}/${file}-${buildEnv}.properties", tofile: "${dir}/${file}.properties", overwrite: 'true')
@@ -123,8 +128,8 @@ task localizeConfig(type: Copy) {
 
 tasks.register("verifyLauncherJar", Jar) {
     ext.verifyLauncherClasspath = { ->
-      def verifyLibs = [configurations.interlokRuntime.collect { "file:///" + it.getCanonicalPath() }.join(' '),
-              configurations.interlokVerify.collect { "file:///" + it.getCanonicalPath() + "/" }.join(' ')]
+      def verifyLibs = [configurations.interlokRuntime.collect { asFileUrl(it.getCanonicalPath()) }.join(' '),
+              configurations.interlokVerify.collect { asFileUrl(it.getCanonicalPath()) + "/" }.join(' ')]
       return verifyLibs.join(' ')
     }
     appendix = "verify-launcher"
@@ -179,9 +184,9 @@ interlokVerify.configure {
 tasks.register("serviceTesterLauncherJar", Jar) {
     appendix = "service-tester-launcher"
     ext.serviceTesterClasspath = { ->
-      def testerLibs = [configurations.interlokRuntime.collect { "file:///" + it.getCanonicalPath() }.join(' '),
-              configurations.interlokTestRuntime.collect { "file:///" + it.getCanonicalPath() }.join(' '),
-              "file:///" + new File("$projectDir/src/test/resources").getCanonicalPath() + "/"]
+      def testerLibs = [configurations.interlokRuntime.collect { asFileUrl(it.getCanonicalPath()) }.join(' '),
+              configurations.interlokTestRuntime.collect { asFileUrl(it.getCanonicalPath()) }.join(' '),
+              asFileUrl(new File("$projectDir/src/test/resources").getCanonicalPath()) + "/"]
       return testerLibs.join(' ')
     }
     manifest {


### PR DESCRIPTION
## Motivation

If your project directory contains spaces; service-tester doesn't execute.

## Modification

Add a function that turns a filepath into a file:/// URL.

## Result

No functional change if you don't have spaces.
gradle check works if you do.

## Testing

Build a build.gradle that refers to this branch in a directory that has spaces (you can probably just use build-parent-json-csv).
