### PR TITLE
Add a default task(s) to the build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ ext {
   includeWar = project.hasProperty('includeWar') ? project.getProperty('includeWar') : 'false'
 }
 
+defaultTasks 'clean', 'check'
+
 ext.buildDetails = [
   isDevMode: { ->
     return buildEnv.equals("dev")
@@ -283,5 +285,3 @@ installDist {
 
 check.dependsOn interlokVerify,interlokServiceTest,interlokVersionReport
 assemble.dependsOn installDist
-
-


### PR DESCRIPTION
## Motivation

Most people won't remember what to type... so add a default task to the parent build gradle so they can just type `./gradlew` and at least get something useful.

## Modification

Added to build.gradle : 
```
defaultTasks 'clean', 'check'
```

## Result

`./gradlew` by itself is the equivalent of `gradle clean check` which runs service-tester and verifies configuration.

## Testing

Create a project that relies on parent gradle and you should see this : 

```
lchan@wsl ~/work/runtime/gradle-nightly/kafka
$ ./gradlew tasks

> Task :tasks

------------------------------------------------------------
Tasks runnable from root project
------------------------------------------------------------

Default tasks: clean, check

Build tasks
-----------
assemble - Assembles the outputs of this project.
```

After that just run `./gradlew` by itself.
