### PR TITLE
INTERLOK-3197 Use jakarta.mail not javax.mail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ configurations {
     all*.exclude group: 'org.hibernate', module: 'hibernate-validator'
     // INTERLOK-3197 exclude old javax.mail
     all*.exclude group: 'com.sun.mail', module: 'javax.mail'
+    all*.exclude group: 'javax.validation', module: 'validation-api'
+    all*.exclude group: 'javax.activation', module: 'activation'
+    all*.exclude group: 'javax.activation', module: 'javax.activation-api'
 }
 
 
@@ -101,6 +104,8 @@ dependencies {
   interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}")
   interlokRuntime ("org.apache.logging.log4j:log4j-api:$log4j2Version")
   interlokRuntime ("com.sun.mail:jakarta.mail:1.6.5")
+  interlokRuntime ("com.sun.activation:jakarta.activation:1.2.2")
+  interlokRuntime ("jakarta.validation:jakarta.validation-api:2.0.2")
 
   interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
   interlokWar  ("com.adaptris.ui:interlok:$interlokUiVersion@war") {changing=true}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ ext {
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.13.1'
   slf4jVersion='1.7.30'
-  interlokVersion = project.hasProperty('interlokVersion') ? project.getProperty('interlokVersion') : '3.9.3-RELEASE'
+  interlokVersion = project.hasProperty('interlokVersion') ? project.getProperty('interlokVersion') : '3.10.0-RELEASE'
   interlokUiVersion = project.hasProperty('interlokUiVersion') ? project.getProperty('interlokUiVersion') : interlokVersion
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
@@ -64,10 +64,11 @@ configurations {
     all*.exclude group: 'xalan', module: 'xalan'
     all*.exclude group: 'net.sf.saxon', module: 'saxon'
     all*.exclude group: 'org.codehaus.woodstox'
-    all*.exclude group: 'com.fasterxml.woodstox'
     all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
     all*.exclude group: 'javax.el', module: 'javax.el-api'
     all*.exclude group: 'org.hibernate', module: 'hibernate-validator'
+    // INTERLOK-3197 exclude old javax.mail
+    all*.exclude group: 'com.sun.mail', module: 'javax.mail'
 }
 
 
@@ -99,6 +100,7 @@ dependencies {
   interlokRuntime ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
   interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}")
   interlokRuntime ("org.apache.logging.log4j:log4j-api:$log4j2Version")
+  interlokRuntime ("com.sun.mail:jakarta.mail:1.6.5")
 
   interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
   interlokWar  ("com.adaptris.ui:interlok:$interlokUiVersion@war") {changing=true}


### PR DESCRIPTION
## Motivation

Since want to switch from javax.mail -> jakarta.mail we have to exclude references to javax.mail from the build-parent. However, people may still use it with a 3.9.x which means that we have
to add the appropriate jakarta.mail artefact into the parent build gradle.

## Modification

- Bump to 3.10.0-RELEASE
- exclude javax.mail and include jakarta.mail instead in the parent
- Remove fasterxml.woodstox as an exclusion since this now works with cdata; they can exclude it as required.

## Result

No functional change; since jakarta.mail 1.6.5 is compatible with javax.mail-1.6.2

## Testing

Do a build, and check the build/distribution/lib directory. 
* jakarta.mail.jar, jakarta.activation.jar, jakarta.validation-api.jar _should exist_
* activation.jar, javax.mail.jar, javax.activation-api.jar, validation-api.jar _should not exist_

Do a build with the master branch (just build https://github.com/adaptris-labs/build-parent-json-csv) and check the build/distribution/lib directory; and the reverse of the above will be true (or at least mostly true)

```
java -Dinterlok.bootstrap.debug=true -jar lib/interlok-boot.jar --configcheck
```

Check the output at the end; there will be "conflicts" from websocket / jms (if SonicMQ), but none around javax.activation / javax.validation.

