### PR TITLE
add additionalTemplated capability for localizing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,23 @@ java -jar lib/interlok-boot.jar
 
 There is support for build environments; you can pass in a gradle property to specify the build environment `gradle -PbuildEnv=myEnv clean check`. What this does is to copy the file `variables-local-{buildenv}.properties` to variables-local.properties so that you can potentially override various settings on a per build basis. If the `buildEnv` is set to the _dev_ then the service tester jars are copied into the distribution in the expectation that you will be using the UI service tester page.
 
+The same is possible with `log4j2.xml` by creating files with the following pattern `log4j2.xml.{buildenv}`.
+
 If you don't want to assemble into `./build/distribution` then you can override that location by defining a `interlokDistDirectory=` in your gradle properties (or on the commandline). We generally discourage this, unless you are only running the assemble task.
+
+### Additional Build Specific Configuration
+
+If you need additional build specific configuration, these can be added by setting the follow properties `additionalFilesWithTemplate` or `additionalFilesWithPropertiesTemplate`: 
+
+```
+additionalFilesWithTemplate = [
+  'jetty.xml'
+]
+
+additionalFilesWithPropertiesTemplate = [
+  'kinesis-local'
+]
+```
 
 ### Overriding system properties / environment variables during InterlokVerify
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ If you don't want to assemble into `./build/distribution` then you can override 
 
 ### Additional Build Specific Configuration
 
-If you need additional build specific configuration, these can be added by setting the follow properties `additionalFilesWithTemplate` or `additionalFilesWithPropertiesTemplate`: 
+If you need additional build specific configuration, these can be added by setting the follow properties `additionalTemplatedConfiguration` or `additionalTemplatedProperties`:
 
 ```
-additionalFilesWithTemplate = [
+additionalTemplatedConfiguration = [
   'jetty.xml'
 ]
 
-additionalFilesWithPropertiesTemplate = [
+additionalTemplatedProperties = [
   'kinesis-local'
 ]
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ configurations {
 if (interlokVersion.endsWith("SNAPSHOT") || interlokUiVersion.endsWith("SNAPSHOT")) {
   allprojects {
     configurations.all {
-      resolutionStrategy.cacheChangingModulesFor 0, "seconds"
+      resolutionStrategy.cacheChangingModulesFor 15, "minutes"
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ ext {
   interlokDistDirectory = project.hasProperty('interlokDistDirectory') ? project.getProperty('interlokDistDirectory') :  "${buildDir}/distribution"
   buildEnv = project.hasProperty('buildEnv') ? project.getProperty('buildEnv') : 'NoBuildEnv'
   includeWar = project.hasProperty('includeWar') ? project.getProperty('includeWar') : 'false'
+  additionalFilesWithTemplate = project.hasProperty('additionalFilesWithTemplate') ? project.getProperty('additionalFilesWithTemplate') : []
+  additionalFilesWithPropertiesTemplate = project.hasProperty('additionalFilesWithPropertiesTemplate') ? project.getProperty('additionalFilesWithPropertiesTemplate') : []
 }
 
 defaultTasks 'clean', 'check'
@@ -124,7 +126,13 @@ task localizeConfig(type: Copy) {
     into "${interlokTmpConfigDirectory}"
     doLast {
         overwriteWithTemplate("log4j2.xml", "${interlokTmpConfigDirectory}")
+        additionalFilesWithTemplate.each {
+          overwriteWithTemplate("${it}", "${interlokTmpConfigDirectory}")
+        }
         overwriteWithPropertiesTemplate("variables-local", "${interlokTmpConfigDirectory}")
+        additionalFilesWithPropertiesTemplate.each {
+          overwriteWithPropertiesTemplate("${it}", "${interlokTmpConfigDirectory}")
+        }
         ant.propertyfile(
             file: "${interlokTmpConfigDirectory}/version.properties") {
             entry( key: "build.version", value: "${version}")

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ ext {
   interlokDistDirectory = project.hasProperty('interlokDistDirectory') ? project.getProperty('interlokDistDirectory') :  "${buildDir}/distribution"
   buildEnv = project.hasProperty('buildEnv') ? project.getProperty('buildEnv') : 'NoBuildEnv'
   includeWar = project.hasProperty('includeWar') ? project.getProperty('includeWar') : 'false'
-  additionalFilesWithTemplate = project.hasProperty('additionalFilesWithTemplate') ? project.getProperty('additionalFilesWithTemplate') : []
-  additionalFilesWithPropertiesTemplate = project.hasProperty('additionalFilesWithPropertiesTemplate') ? project.getProperty('additionalFilesWithPropertiesTemplate') : []
+  additionalTemplatedConfiguration = project.hasProperty('additionalTemplatedConfiguration') ? project.getProperty('additionalTemplatedConfiguration') : []
+  additionalTemplatedProperties = project.hasProperty('additionalTemplatedProperties') ? project.getProperty('additionalTemplatedProperties') : []
 }
 
 defaultTasks 'clean', 'check'
@@ -126,11 +126,11 @@ task localizeConfig(type: Copy) {
     into "${interlokTmpConfigDirectory}"
     doLast {
         overwriteWithTemplate("log4j2.xml", "${interlokTmpConfigDirectory}")
-        additionalFilesWithTemplate.each {
+        additionalTemplatedConfiguration.each {
           overwriteWithTemplate("${it}", "${interlokTmpConfigDirectory}")
         }
         overwriteWithPropertiesTemplate("variables-local", "${interlokTmpConfigDirectory}")
-        additionalFilesWithPropertiesTemplate.each {
+        additionalTemplatedProperties.each {
           overwriteWithPropertiesTemplate("${it}", "${interlokTmpConfigDirectory}")
         }
         ant.propertyfile(


### PR DESCRIPTION
## Motivation

Allow users to customise localizeConfig functionality

## Modification

Added two new properties `additionalTemplatedConfiguration` and `additionalTemplatedProperties` with default of an empty array.

Then based on these values execute the respective helper functions.

## Result

Allow users additional environment specific configuration, ex: `jetty.xml` or `kinesis-local.properties`

## Testing

How can I test this if I'm reviewing this.

1. Add the following block to the `ext` of your project:
```
additionalTemplatedConfiguration= [
  'jetty.xml'
]
additionalTemplatedProperties= [
  'kinesis-local'
]
```
2. Create jetty.xml.myEnv and kinesis-local-myEnv.properties`
3. Run the following with and without `buildEnv` set: `gradle -PbuildEnv=myEnv clean install`

