### PR TITLE
INTERLOK-3199 Add owasp capability into the parent gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,11 +308,11 @@ installDist {
     destinationDir = new File(interlokDistDirectory)
 }
 
-dependencyCheckAnalyze {
-  onlyIf {
-    !buildDetails.isDevMode()
-  }
-}
+// dependencyCheckAnalyze {
+//   onlyIf {
+//     !buildDetails.isDevMode()
+//   }
+// }
 
 dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
@@ -320,5 +320,6 @@ dependencyCheck  {
   failBuildOnCVSS = 7
 }
 
-check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
+// check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
+check.dependsOn interlokVerify,interlokServiceTest,interlokVersionReport
 assemble.dependsOn installDist

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+  repositories {
+    maven { url 'https://plugins.gradle.org/m2/' }
+  }
+  dependencies {
+    classpath 'org.owasp:dependency-check-gradle:5.3.2.1'
+  }
+}
+
+apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 apply plugin: "distribution"
 
 ext {
@@ -298,5 +308,17 @@ installDist {
     destinationDir = new File(interlokDistDirectory)
 }
 
-check.dependsOn interlokVerify,interlokServiceTest,interlokVersionReport
+dependencyCheckAnalyze {
+  onlyIf {
+    !buildDetails.isDevMode()
+  }
+}
+
+dependencyCheck  {
+  suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
+  skipConfigurations = [ "interlokJavadocs", "interlokVerify" ,"antJunit"]
+  failBuildOnCVSS = 7
+}
+
+check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
 assemble.dependsOn installDist

--- a/build.gradle
+++ b/build.gradle
@@ -316,7 +316,7 @@ installDist {
 
 dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
-  skipConfigurations = [ "interlokJavadocs", "interlokVerify" ,"antJunit"]
+  skipConfigurations = buildDetails.isIncludeWar() ? [ "interlokJavadocs", "interlokVerify" ,"antJunit" ] : [ "interlokWar", "interlokJavadocs", "interlokVerify" ,"antJunit" ]
   failBuildOnCVSS = 7
 }
 


### PR DESCRIPTION
## Motivation

Since owasp dependency checks aren't a built in plugin; it's not entirely obvious how to make it available in the parent gradle; even though the configuration fothe dependency checks is going be
largely similar for all child projects.


## Modification

Using the classname of the plugin we can force its inclusion in the build.gradle with a default `dependencyCheck` configuration which points to the standard include.

## Result

No change; unless they specifically execute `gradle dependencyCheckAnalyze`

## Testing

Modify the build-parent-json-csv project to point to this branch and run `gradle dependencyCheckAnalyze` (it will likely fail due to a new commons-configuration CVE in interlok-ui).
