### PR TITLE
only execute on interlokVerifyReport on sucess of interlokVerify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ def interlokVerify = tasks.register("interlokVerify", JavaExec) {
         standardOutput.writeTo(stream)
       }
       if (warningsCount > 0) {
-        println "Interlok Verify contains warnings [$warningsCount]"
+        println "\nConfiguration warnings [$warningsCount]:"
         print verifyOutput
         if(verifyMode == VerifyModes.STRICT) {
           throw new GradleException("Interlok Verify contains warnings [$warningsCount]")
@@ -247,7 +247,7 @@ def interlokVerifyReport = tasks.register("interlokVerifyReport", JavaExec) {
     group = 'Test'
     description = 'Create Interlok verify test reports'
     onlyIf{
-      interlokVerify.get().didWork
+      interlokVerify.get().didWork && !interlokVerify.get().state.failure && new File(interlokVerifyTextReport).exists()
     }
     main = 'com.adaptris.labs.verify.CreateVerifyReport'
     classpath = configurations.interlokVerifyReport

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ def interlokVerifyReport = tasks.register("interlokVerifyReport", JavaExec) {
     group = 'Test'
     description = 'Create Interlok verify test reports'
     onlyIf{
-      interlokVerify.get().didWork && !interlokVerify.get().state.failure && new File(interlokVerifyTextReport).exists()
+      interlokVerify.get().didWork && new File(interlokVerifyTextReport).exists()
     }
     main = 'com.adaptris.labs.verify.CreateVerifyReport'
     classpath = configurations.interlokVerifyReport


### PR DESCRIPTION
## Motivation

If `interlokVerify` fails `interlokVerifyReport` still executes.

`interlokVerifyReport` should only run when `interlokVerify`  is successful and report.txt is present.

Fixes #20 

## Modification

Update `onlyIf` to check ~status of `interlokVerify` and~ if file exists.

## Result

When `interlokVerify` fails to create report.txt  the user won't see an error about `interlokVerifyReport`

## Testing

Checkout branch, and update a project using the build parent with the following properties:

```
interlokParentGradle = file:///<path>/adaptris-labs/interlok-build-parent/build.gradle
interlokParentBaseUrl = file:///<path>/adaptris-labs/interlok-build-parent
```
