### PR TITLE
Make nexusBaseUrl a property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 apply plugin: "distribution"
 
 ext {
-  nexusBaseUrl  = 'https://nexus.adaptris.net'
+  nexusBaseUrl  = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net'
   log4j2Version='2.13.3'
   slf4jVersion='1.7.30'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.10.1-RELEASE'


### PR DESCRIPTION
## Motivation

`nexusBaseUrl` is hard set to be nexus.adaptris.net. It should be a property so that we can have alternative base repositories (local or otherwise).

## Modification

nexusBaseUrl=project.findProperty()

## Result

No Change for most people.

## Testing

```
gradle -PnexusBaseUrl=http://nexus.agb.rbxd.ds clean assemble
```
