### PR TITLE
Add support for a localInterlokRepo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 apply plugin: "distribution"
 
 ext {
-  nexusBaseUrl  = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net'
+  localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'
+  nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.13.3'
   slf4jVersion='1.7.30'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.10.1-RELEASE'
@@ -112,6 +113,9 @@ repositories {
       content {
         excludeGroupByRegex "com\\.adaptris.*"
       }
+    }
+    if (localInterlokRepo != "unknown") {
+      maven { url "$localInterlokRepo" }
     }
     maven { url "${nexusBaseUrl}/nexus/content/groups/public" }
     maven { url "${nexusBaseUrl}/nexus/content/groups/interlok" }


### PR DESCRIPTION
## Motivation

If you're in a situation where things are unreliable connecting to nexus.adaptris.net then you might have a local mirror. Support the use of a local mirror to resolve interlok components.

## Modification

Add a `localInterlokRepo` property that defaults to unknown (in which case it is unused); but if used then it can be set to any URL.

- Implicitly supports mavenLocal if localInterlokRepo is set to `file:///path-to-home/.m2/repository`
- if you have a local mirror then something like `http://my-local-mirror/groups/interlok`
- Revert change to find nexusBaseUrl by property since this forces people to have the same "nexus path structure" as we do, which is a poor assumption to make.

## Result

No change for the end user until they set the property

## Testing

* Set up a local mirror, or use your local maven repository.
```
$ cat ./gradle.properties
localInterlokRepo=file:////Users/chanl3/.m2/repository
```
* ./gradle clean assemble 