### PR TITLE
Exclude woodstox-core-asl since this is replaced by woodstox-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,9 @@ configurations {
     all*.exclude group: 'org.glassfish.hk2.external'
     all*.exclude group: 'xalan', module: 'xalan'
     all*.exclude group: 'net.sf.saxon', module: 'saxon'
-    all*.exclude group: 'org.codehaus.woodstox'
+    // Exclude because com.fasterxml.woodstox:woodstox-core should take precedence
+    // however, stax2-api still lives on in the org.codehaus.woodstox group
+    all*.exclude group: 'org.codehaus.woodstox', module: 'woodstox-core-asl'
     all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
     all*.exclude group: 'javax.el', module: 'javax.el-api'
     all*.exclude group: 'org.hibernate', module: 'hibernate-validator'


### PR DESCRIPTION
## Motivation

We were excluding the `org.codehaus.woodstox` group, since it should have been replaced by the com.fasterxml.woodstox group. Sadly however, the stax2-api jar still lives in the org.codehaus.woodstox group 

## Modification

Only exclude the woodstox-core-asl core which has been replaced by `com.fasterxml.woodstox:woodstox-core`

## Result

If you depend on `interlok-webservice-cxf` then stax2-api.jar will now be present in the lib directory.

## Testing

As above; if you change the exclusion back to the entire group, then stax2-api.jar isn't in build/distribution/lib and Interlok will fail to start (the UI will fail to start if nothing else).
You can force interlok + xstream to do the right thing by using `-Dinterlok.xstream.jdk.stax=true`
