### PR TITLE
Allow environment properties to loaded from file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ ext {
   verifyMode  = project.hasProperty('verifyMode') ? VerifyModes.valueOf(project.getProperty('verifyMode')) : VerifyModes.WARN
   interlokVerifyTextReport = "${buildDir}/reports/interlok/verify/report.txt"
   interlokVerifySonarReport = "${buildDir}/reports/interlok/verify/report.json"
+  interlokVerifyEnvironmentPropertiesFile = project.findProperty('interlokVerifyEnvironmentPropertiesFile') ?: "${projectDir}/.env"
 }
 
 enum VerifyModes {
@@ -50,6 +51,17 @@ ext.buildDetails = [
     return includeWar.equals("true") || buildEnv.equals("dev")
   }
 ]
+
+def loadPropertiesFromFile(filepath) {
+  Properties properties = new Properties()
+  File propertiesFile = new File(filepath)
+  if(propertiesFile.exists()){
+    propertiesFile.withInputStream {
+      properties.load(it)
+    }
+  }
+  return properties
+}
 
 def asFileUrl(filepath) {
   return "file:///" + new java.net.URI(null, filepath, null).toASCIIString();
@@ -224,6 +236,7 @@ def interlokVerify = tasks.register("interlokVerify", JavaExec) {
     classpath = files(verifyLauncherJar.archivePath)
     main = 'com.adaptris.core.management.SimpleBootstrap'
     args "-configtest"
+    environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
     environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
     systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
     systemProperty "interlok.logging.url", verifyLog4j


### PR DESCRIPTION
## Motivation

Loading environment variables used from .env file that would be checked in.

## Modification

Create loadPropertiesFromFile function and added to interlokVerify environment variables.

## Result

This would allow users to have build.gradle like (NOTE: no `interlokVerifyEnvironmentProperties`):

```gradle
ext {
  interlokParentGradle = 'https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/master/build.gradle'

  buildEnv = project.hasProperty('buildEnv') ? project.getProperty('buildEnv') : 'env'
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-aws-s3:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-workflow-rest-services:$interlokVersion") {changing= true}
  interlokRuntime ("org.postgresql:postgresql:42.2.14")

}
```

And then a `docker-compose.yaml` for local testing:

```yaml
version: '3.2'
services:
  interlok:
    build:
      context: .
      dockerfile: dockerfile
    ports:
      - "8090:8080"
    env_file:
     - .env
```


## Testing

1. Create `.env` with `interlokVerifyEnvironmentProperties`
2. Refer locally checkout parent `file:///...../build.gralde`
3. Remove `interlokVerifyEnvironmentProperties`
4. `gradle clean check`