### PR TITLE
INTERLOK-3497 Support ConfigurationReporter in parent gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,6 +311,9 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   systemProperty "interlok.verify.deprecated.filename", interlokVerifyTextReport
   systemProperty "interlok.verify.deprecated.category", interlokVerifyCategory
   systemProperty "interlok.verify.deprecated.level", interlokVerifyLevel
+  systemProperty "interlok.verify.warning.filename", interlokVerifyTextReport
+  systemProperty "interlok.verify.warning.category", interlokVerifyCategory
+  systemProperty "interlok.verify.warning.level", interlokVerifyLevel
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -308,9 +308,6 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
-  systemProperty "interlok.verify.deprecated.filename", interlokVerifyTextReport
-  systemProperty "interlok.verify.deprecated.category", interlokVerifyCategory
-  systemProperty "interlok.verify.deprecated.level", interlokVerifyLevel
   systemProperty "interlok.verify.warning.filename", interlokVerifyTextReport
   systemProperty "interlok.verify.warning.category", interlokVerifyCategory
   systemProperty "interlok.verify.warning.level", interlokVerifyLevel

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.VersionNumber
+
 buildscript {
   repositories {
     maven { url 'https://plugins.gradle.org/m2/' }
@@ -16,6 +18,7 @@ ext {
   log4j2Version='2.14.0'
   slf4jVersion='1.7.30'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.11.1-RELEASE'
+  verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
@@ -32,6 +35,7 @@ ext {
   serviceTestLog4j = "${interlokParentBaseUrl}/serviceTestLog4j2.xml"
   verifyMode  = project.hasProperty('verifyMode') ? VerifyModes.valueOf(project.getProperty('verifyMode')) : VerifyModes.WARN
   interlokVerifyTextReport = "${buildDir}/reports/interlok/verify/report.txt"
+  interlokVerifyTextReportFile = new File(interlokVerifyTextReport)
   interlokVerifySonarReport = "${buildDir}/reports/interlok/verify/report.json"
   interlokVerifyEnvironmentPropertiesFile = project.findProperty('interlokVerifyEnvironmentPropertiesFile') ?: "${projectDir}/.env"
 }
@@ -49,6 +53,36 @@ ext.buildDetails = [
 
   isIncludeWar: { ->
     return includeWar.equals("true") || buildEnv.equals("dev")
+  }
+
+]
+
+ext.verifyReport = [
+
+  verifyViaConfigCheck: { ->
+    return VersionNumber.parse( interlokVersion ) >= VersionNumber.parse( verifyReportConfigCheckAvailable )
+  },
+
+  verifyReportFile: { ->
+    if (interlokVerifyTextReportFile.exists()) {
+      def content = java.nio.file.Files.readAllLines(interlokVerifyTextReportFile.toPath())
+      def warningsCount = content.size()
+      // Has the sad effect of printing out CODE_SMELL, but that's acceptable.
+      if (warningsCount > 0) {
+        println "\nConfiguration warnings [$warningsCount]:"
+        content.each {
+          println it
+        }
+        if(verifyMode == VerifyModes.STRICT) {
+          throw new GradleException("Interlok Verify contains warnings [$warningsCount]")
+        }
+      }
+    }
+  },
+
+  init: { ->
+    delete interlokVerifyTextReportFile
+    mkdir(interlokVerifyTextReportFile.getParentFile())
   }
 ]
 
@@ -189,8 +223,6 @@ task localizeConfig(type: Copy) {
 }
 
 task getServiceTestLog4j2 (){
-  group 'Verification'
-  description 'Get service test log4j2.xml'
   outputs.file new File(interlokTmpServiceTestLog4j)
   doLast {
     mkdir(new File(interlokTmpServiceTestLog4j).getParentFile())
@@ -224,62 +256,96 @@ interlokVersionReport.configure {
     dependsOn localizeConfig, verifyLauncherJar
 }
 
-def interlokVerify = tasks.register("interlokVerify", JavaExec) {
-    group = 'Verification'
-    description = 'Check if Interlok config is valid using -configtest'
-    doFirst {
-      if(new File("$interlokTmpConfigDirectory/log4j2.xml").exists()) {
-        ant.move file: "$interlokTmpConfigDirectory/log4j2.xml", tofile: "$interlokTmpConfigDirectory/log4j2.xml.bk"
-      }
+def interlokVerifyLog4j= tasks.register("interlokVerifyLog4j", JavaExec) {
+  group = 'Verification'
+  description = 'Interlok config test using -configtest reporting by parsing console output (pre 3.12)'
+  onlyIf{
+    !verifyReport.verifyViaConfigCheck()
+  }
+  doFirst {
+    if(new File("$interlokTmpConfigDirectory/log4j2.xml").exists()) {
+      ant.move file: "$interlokTmpConfigDirectory/log4j2.xml", tofile: "$interlokTmpConfigDirectory/log4j2.xml.bk"
     }
-    workingDir = new File("${buildDir}/tmp")
-    classpath = files(verifyLauncherJar.archivePath)
-    main = 'com.adaptris.core.management.SimpleBootstrap'
-    args "-configtest"
-    environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
-    environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
-    systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
-    systemProperty "interlok.logging.url", verifyLog4j
-    standardOutput = new ByteArrayOutputStream()
-    doLast {
-      def verifyOutput = standardOutput.toString()
-      def warningsCount = verifyOutput.readLines().size()
-      def reportFile = new File(interlokVerifyTextReport)
-      mkdir(reportFile.getParentFile())
-      reportFile.createNewFile()
-      verifyOutput.eachLine {
-        reportFile.append("CODE_SMELL,INFO," + it + "\n")
-      }
-      if (warningsCount > 0) {
-        println "\nConfiguration warnings [$warningsCount]:"
-        print verifyOutput
-        if(verifyMode == VerifyModes.STRICT) {
-          throw new GradleException("Interlok Verify contains warnings [$warningsCount]")
-        }
-      }
-      if(new File("$interlokTmpConfigDirectory/log4j2.xml.bk").exists()) {
-        ant.move file: "$interlokTmpConfigDirectory/log4j2.xml.bk", tofile: "$interlokTmpConfigDirectory/log4j2.xml"
-      }
+    verifyReport.init()
+  }
+  workingDir = new File("${buildDir}/tmp")
+  classpath = files(verifyLauncherJar.archivePath)
+  main = 'com.adaptris.core.management.SimpleBootstrap'
+  args "-configtest"
+  environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
+  environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
+  systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
+  systemProperty "interlok.logging.url", verifyLog4j
+  standardOutput = new ByteArrayOutputStream()
+  doLast {
+    def verifyOutput = standardOutput.toString()
+    interlokVerifyTextReportFile.createNewFile()
+    verifyOutput.eachLine {
+      interlokVerifyTextReportFile.append("CODE_SMELL,INFO," + it + "\n")
     }
+    if(new File("$interlokTmpConfigDirectory/log4j2.xml.bk").exists()) {
+      ant.move file: "$interlokTmpConfigDirectory/log4j2.xml.bk", tofile: "$interlokTmpConfigDirectory/log4j2.xml"
+    }
+  }
+}
+
+def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaExec) {
+  group = 'Verification'
+  description = 'Interlok config test using -configtest reporting via a ConfigurationChecker implementation'
+  onlyIf{
+    verifyReport.verifyViaConfigCheck()
+  }
+  doFirst {
+    verifyReport.init()
+  }
+  workingDir = new File("${buildDir}/tmp")
+  classpath = files(verifyLauncherJar.archivePath)
+  main = 'com.adaptris.core.management.SimpleBootstrap'
+  args "-configtest"
+  environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
+  environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
+  systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
+  systemProperty "interlok.verify.deprecated.filename", interlokVerifyTextReport
+  // systemProperty "interlok.verify.deprecated.category", "CODE_SMELL"
+  // systemProperty "interlok.verify.deprecated.level", "INFO"
+}
+
+
+def interlokVerify = tasks.register("interlokVerify") {
+  group = 'Verification'
+  description = 'Wrapper around interlokVerifyConfigCheck / interlokVerifyLog4j'
+  doLast {
+    verifyReport.verifyReportFile()
+  }
 }
 
 def interlokVerifyReport = tasks.register("interlokVerifyReport", JavaExec) {
-    group = 'Test'
-    description = 'Create Interlok verify test reports'
-    onlyIf{
-      interlokVerify.get().didWork && new File(interlokVerifyTextReport).exists()
-    }
-    main = 'com.adaptris.labs.verify.CreateVerifyReport'
-    classpath = configurations.interlokVerifyReport
-    args "--reportFile"
-    args interlokVerifyTextReport
-    args "--outputFile"
-    args interlokVerifySonarReport
+  group = 'Verification'
+  description = 'Create Interlok Sonarqube reports from config verification'
+  onlyIf{
+    // technicaly interlokVerify won't do work so interlokVerify.get().didWork won't be true...
+    // (interlokVerifyConfigCheck.get().didWork || interlokVerifyLog4j.get().didWork) && new File(interlokVerifyTextReport).exists()
+    interlokVerify.get().didWork && new File(interlokVerifyTextReport).exists()
+  }
+  main = 'com.adaptris.labs.verify.CreateVerifyReport'
+  classpath = configurations.interlokVerifyReport
+  args "--reportFile"
+  args interlokVerifyTextReport
+  args "--outputFile"
+  args interlokVerifySonarReport
 }
 
 interlokVerify.configure {
-    dependsOn localizeConfig, verifyLauncherJar
-    finalizedBy interlokVerifyReport
+  dependsOn interlokVerifyConfigCheck, interlokVerifyLog4j
+  finalizedBy interlokVerifyReport
+}
+
+interlokVerifyConfigCheck.configure {
+  dependsOn localizeConfig, verifyLauncherJar
+}
+
+interlokVerifyLog4j.configure {
+  dependsOn localizeConfig, verifyLauncherJar
 }
 
 tasks.register("serviceTesterLauncherJar", Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ ext {
   interlokVerifyTextReportFile = new File(interlokVerifyTextReport)
   interlokVerifySonarReport = "${buildDir}/reports/interlok/verify/report.json"
   interlokVerifyEnvironmentPropertiesFile = project.findProperty('interlokVerifyEnvironmentPropertiesFile') ?: "${projectDir}/.env"
+  interlokVerifyCategory = project.findProperty('interlokVerifyCategory') ?: "CODE_SMELL"
+  interlokVerifyLevel = project.findProperty('interlokVerifyLevel') ?: "INFO"
+  interlokVerifyPrefix = "$interlokVerifyCategory,$interlokVerifyLevel,"
 }
 
 enum VerifyModes {
@@ -71,7 +74,7 @@ ext.verifyReport = [
       if (warningsCount > 0) {
         println "\nConfiguration warnings [$warningsCount]:"
         content.each {
-          println it
+          println it.replaceAll(interlokVerifyPrefix, "")
         }
         if(verifyMode == VerifyModes.STRICT) {
           throw new GradleException("Interlok Verify contains warnings [$warningsCount]")
@@ -281,7 +284,7 @@ def interlokVerifyLog4j= tasks.register("interlokVerifyLog4j", JavaExec) {
     def verifyOutput = standardOutput.toString()
     interlokVerifyTextReportFile.createNewFile()
     verifyOutput.eachLine {
-      interlokVerifyTextReportFile.append("CODE_SMELL,INFO," + it + "\n")
+      interlokVerifyTextReportFile.append(interlokVerifyPrefix + it + "\n")
     }
     if(new File("$interlokTmpConfigDirectory/log4j2.xml.bk").exists()) {
       ant.move file: "$interlokTmpConfigDirectory/log4j2.xml.bk", tofile: "$interlokTmpConfigDirectory/log4j2.xml"
@@ -306,8 +309,8 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
   systemProperty "interlok.verify.deprecated.filename", interlokVerifyTextReport
-  // systemProperty "interlok.verify.deprecated.category", "CODE_SMELL"
-  // systemProperty "interlok.verify.deprecated.level", "INFO"
+  systemProperty "interlok.verify.deprecated.category", interlokVerifyCategory
+  systemProperty "interlok.verify.deprecated.level", interlokVerifyLevel
 }
 
 


### PR DESCRIPTION
## Motivation

- INTERLOK-3287 (https://github.com/adaptris/interlok/pull/546) introduced a new ConfigDeprecation annotation which is more formal than relying on the "developer" to log warnings about deprecated components.
- INTERLOK-3497 (https://github.com/adaptris/interlok/pull/579) added in the capability for a report file to be generated in the correct format if various system properties are set.

This PR changes the parent build.gradle to build on those two changes.

## Modification

Use `org.gradle.util.VersionNumber.parse()` to do tests against the interlokVersion. Switch to using https://github.com/adaptris/interlok/pull/579 implementations when running -configtest if version >=3.12. _VersionNumber_ works well enough with our current versioning convention

```
import org.gradle.util.VersionNumber
 
def checkVersion(version) {
  return VersionNumber.parse( version ) >= VersionNumber.parse( '3.12-SNAPSHOT' )
}
 
task checkVersion {
 
  doLast {
    def versions = ["3.9-SNAPSHOT", "3.9.2-RELEASE", "3.9.3-RELEASE", "3.9.3.1-RELEASE", "3.9.3.2-RELEASE", "3.10-SNAPSHOT", "3.10.0-RELEASE", "3.10.1-RELEASE", "3.10.2-RELEASE", "3.11-SNAPSHOT-RELEASE", "3.11.0-RELEASE", "3.11.1-RELEASE", "3.12-SNAPSHOT", "3.12.0-RELEASE", "3.12.1-RELEASE", "4.0.0"] as String[]
    versions.each {
      println "${it} " + checkVersion("${it}")
    }
  }
}
...
> Task :checkVersion
3.9-SNAPSHOT false
3.9.2-RELEASE false
3.9.3-RELEASE false
3.9.3.1-RELEASE false
3.9.3.2-RELEASE false
3.10-SNAPSHOT false
3.10.0-RELEASE false
3.10.1-RELEASE false
3.10.2-RELEASE false
3.11-SNAPSHOT-RELEASE false
3.11.0-RELEASE false
3.11.1-RELEASE false
3.12-SNAPSHOT true
3.12.0-RELEASE false
3.12.1-RELEASE true
4.0.0 true
```

- Added additional helpers for handling report verification etc to avoid duplication of code.

## Result

If the version >= 3.12-SNAPSHOT then we switch to asking -configcheck to generate the report _for us_ so that verifyReport can do work.

~~A side effect of the change ( to avoid code duplication but keep feature parity) is that we now use the report file itself during the reporting phase which means that we see `CODE_SMELL,INFO`...~~

## Testing

If we take the configuration from https://github.com/adaptris/interlok/pull/579 and we have the build.gradle file

```
ext {
  interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/INTERLOK-3497-verify-config-check/build.gradle"
  interlokVersion = '3.11-SNAPSHOT'
}

allprojects {
  apply from: "${interlokParentGradle}"
}

configurations.all {
  resolutionStrategy.cacheChangingModulesFor 0, "seconds"
}

dependencies {
  // These dependencies probably don't matter.
  interlokRuntime ("org.fusesource.jansi:jansi:2.0.1")
}
```

Then we get the relevant output via interlokVerifyLog4j

```
> Task :interlokVerifyLog4j
... // content skipped
> Task :interlokVerify

Configuration warnings [3]:
Configuration warnings [3]:
[AlwaysFailService] is deprecated, use [com.adaptris.core.services.exception.ThrowExceptionService] instead
NullMessageConsumer uses destination, it has no meaning
[Adapter(MyInterlokInstance)] has a MessageErrorHandler with no behaviour; messages may be discarded upon exception
```

If we switch the version to be __3.12-SNAPSHOT__ then we get more meaningful output based on the changes from https://github.com/adaptris/interlok/pull/546 

```
> Task :interlokVerifyConfigCheck
... // logging skipped
> Task :interlokVerify

Configuration warnings [3]:
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination][NullMessageConsumer]: Is deprecated. It will be removed in 4.0.0
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]][AlwaysFailService(always-fail-cos)]: Is deprecated. It will be removed in a future version
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[1].services[0]][AlwaysFailService]: Is deprecated. It will be removed in a future version
```
