### PR TITLE
Switch to scanning interlokRuntime only.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,7 +459,7 @@ installDist {
 
 dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
-  skipConfigurations = buildDetails.isIncludeWar() ? [ "interlokJavadocs", "interlokVerify", "interlokVerifyReport", "antJunit" ] : [ "interlokWar", "interlokJavadocs", "interlokVerify", "interlokVerifyReport", "antJunit" ]
+  scanConfigurations = buildDetails.isIncludeWar() ? [ "interlokWar", "interlokRuntime" ] : [ "interlokRuntime" ]
   failBuildOnCVSS = 7
 }
 


### PR DESCRIPTION
## Motivation

3.11.1-RELEASE has a couple of CVE's that have been fixed by later 3rd party release (xstream + jetty)

Since you might be working on this outside of the maintenance cycle (i.e. you need to use 3.11.1-RELEASE, and aren't yet able to upgrade to 3.12.x or whatever) then you might just update the interlokRuntime with just the correct versions :

e.g.

```
  interlokRuntime ("org.eclipse.jetty.aggregate:jetty-all:9.4.35.v20201120")
  interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.15")
```

However, this will still fail, since you haven't upgraded all the appropriate configurations, you'll also need

```
  interlokTestRuntime ("org.eclipse.jetty.aggregate:jetty-all:9.4.35.v20201120")
  interlokTestRuntime ("com.thoughtworks.xstream:xstream:1.4.15")
```

So, make dependencyCheckAnalyze skip configurations we don't care about in deployment...

## Modification

Since the exclusion list is going to grow, this suggests that we switch to an explicit include model rather than an exclude mode...

```

dependencyCheck  {
  suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
  scanConfigurations = buildDetails.isIncludeWar() ? [ "interlokWar", "interlokRuntime" ] : [ "interlokRuntime" ]
  failBuildOnCVSS = 7
}
```

If we want to stick with skipConfigurations then it would be :

```
dependencyCheck {
...
    skipConfigurations = buildDetails.isIncludeWar() 
      ? [ "interlokJavadocs", "interlokVerify", "interlokVerifyReport", "antJunit" , "interlokTestRuntime" ] 
      : [ "interlokWar", "interlokJavadocs", "interlokVerify", "interlokVerifyReport", "antJunit" , "interlokTestRuntime" ]
}
```

## Result

You can just do (leaving the version at 3.11.1-RELEASE).

```
  interlokRuntime ("org.eclipse.jetty.aggregate:jetty-all:9.4.35.v20201120")
  interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.15")
```

And not get any dependencyCheckAnalyze failures.

## Testing

Pin @ 3.11.1-RELEASE, but make sure that xstream  / jetty is @ the default versions supplied by Interlok.

- gradle dependencyCheckAnalyze will fail since it is also checking the interlokTestRuntime configuration. Make changes as above (`interlokRuntime` only)

Switch to the PR branch
- gradle dependencyCheckAnalyze will pass.