### PR TITLE
use license from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,12 @@ interlokVerifySystemProperties = [
 ### Detecting changes to the parent build gradle.
 
 Since we're using `apply from`; this is effectively treated as a script plugin, which means that it is added to your local module cache (`~/.gradle/caches/modules-2` or similar). This cache is managed by the gradle daemon and any changes will be detected automatically (probably daily). However, in some situations you may be after the latest and greatest version of the parent gradle file. If that's the case then you can use the commandline switch _--refresh-dependencies_ to force gradle to refresh the state of all your dependencies : `./gradlew --refresh-dependences clean check assemble`. This should force a re-download of the parent gradle.
+
+### Interlok License
+
+If you're using licensed components check will fail, the the parent supports reading license keys from environment variables.
+
+```shell
+export INTERLOK_LICENSE_KEY="a.."
+gradle clean check
+```

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ ext {
   interlokVerifyTextReportFile = new File(interlokVerifyTextReport)
   interlokVerifySonarReport = "${buildDir}/reports/interlok/verify/report.json"
   interlokVerifyEnvironmentPropertiesFile = project.findProperty('interlokVerifyEnvironmentPropertiesFile') ?: "${projectDir}/.env"
+  interlokVerifyLicenseProperties = System.env.containsKey("INTERLOK_LICENSE_KEY") ? [ "interlok.license.key": "$System.env.INTERLOK_LICENSE_KEY" ] : [:]
   interlokVerifyCategory = project.findProperty('interlokVerifyCategory') ?: "CODE_SMELL"
   interlokVerifyLevel = project.findProperty('interlokVerifyLevel') ?: "INFO"
   interlokVerifyPrefix = "$interlokVerifyCategory,$interlokVerifyLevel,"
@@ -278,6 +279,7 @@ def interlokVerifyLog4j= tasks.register("interlokVerifyLog4j", JavaExec) {
   environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
+  systemProperties interlokVerifyLicenseProperties
   systemProperty "interlok.logging.url", verifyLog4j
   standardOutput = new ByteArrayOutputStream()
   doLast {
@@ -308,6 +310,7 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
+  systemProperties interlokVerifyLicenseProperties
   systemProperty "interlok.verify.warning.filename", interlokVerifyTextReport
   systemProperty "interlok.verify.warning.category", interlokVerifyCategory
   systemProperty "interlok.verify.warning.level", interlokVerifyLevel


### PR DESCRIPTION
## Motivation

Allow components with license to easily built.

Closes #22 

## Modification

Use environment variable `INTERLOK_LICENSE_KEY` in `check`

## Result

Enables users to build licensed components easily.

## Testing

```shell
export INTERLOK_LICENSE_KEY="a.."
gradle clean check
```

