### PR TITLE
Only add javadocs for war

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,6 +420,14 @@ task interlokWarDist(type: Copy) {
   into interlokTmpWarDirectory
 }
 
+task interlokJavadocsDist(type: Copy) {
+  onlyIf {
+    buildDetails.isIncludeWar()
+  }
+  from project.configurations.interlokJavadocs
+  into interlokTmpDocsDirectory
+}
+
 distributions {
     main {
         contents {
@@ -438,7 +446,7 @@ distributions {
                 from(interlokWarDist)
             }
             into('docs/javadocs') {
-              from(project.configurations.interlokJavadocs)
+              from(interlokJavadocsDist)
             }
             rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
             rename '(.*)-[0-9]+\\..*.war', '$1.war'


### PR DESCRIPTION
## Motivation

When building interlok using the parent for environments that we don't include the war, the docs also get added.

## Modification

Conditionally add javadocs

## Result

Docs jars only added for war builds

## Testing

```shell
gradle clean install -PincludeWar=true
ls ./build/distribution/docs
gradle clean install
ls ./build/distribution/docs
```
