### PR TITLE
Bump versions logging versions and cause build to fail if used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ apply plugin: "distribution"
 ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'
   nexusBaseUrl  = 'https://nexus.adaptris.net'
-  log4j2Version='2.14.1'
-  slf4jVersion='1.7.30'
+  log4j2Version='2.16.0'
+  slf4jVersion='1.7.32'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.12.0-RELEASE'
   verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
@@ -477,9 +477,10 @@ installDist {
 //   }
 // }
 
-task logDeprecation {
+task logDeprecated {
   doLast {
-    logger.warn("#### Switch to using 'https://github.com/adaptris/interlok-build-parent/' instead")
+    logger.error("Switch to use 'https://github.com/adaptris/interlok-build-parent/' instead")
+    throw new GradleException("No longer supported, Please switch to use 'https://github.com/adaptris/interlok-build-parent/'.")
   }
 }
 
@@ -490,5 +491,6 @@ dependencyCheck  {
 }
 
 // check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
-check.dependsOn logDeprecation,interlokVerify,interlokServiceTest,interlokVersionReport
+check.dependsOn logDeprecated,interlokVerify,interlokServiceTest,interlokVersionReport
+installDist.dependsOn logDeprecated
 assemble.dependsOn installDist


### PR DESCRIPTION
## Motivation

This has be deprecated for a while, this is the final step in removing support.

## Modification

Change the warning to an error.

## Result

Builds will now fail and they will have to migrated

```text
$ gradle clean install
> Task :clean
> Task :interlokJavadocsDist SKIPPED
> Task :interlokWarDist SKIPPED
> Task :localizeConfig

> Task :logDeprecated FAILED
Switch to use 'https://github.com/adaptris/interlok-build-parent/' instead

FAILURE: Build failed with an exception.

* Where:
Script '/Users/warmanm/code/src/github.com/adaptris-labs/interlok-build-parent/build.gradle' line: 483

* What went wrong:
Execution failed for task ':logDeprecated'.
> No longer supported, Please switch to use 'https://github.com/adaptris/interlok-build-parent/'.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
3 actionable tasks: 3 executed
```

## Testing

```gradle
ext {
  interlokParentBaseUrl = 'file:///' + '<path_to_checkout>'
  interlokParentGradle = interlokParentBaseUrl + '/build.gradle'
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion")
}
```
